### PR TITLE
fix: removing new line characters

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,11 +11,12 @@ module.exports = function(content) {
 
 	content = content.toString('utf8');
 	content = content.replace(/"/g, "'");
+	content = content.replace(/\s+/g, " ");
 	content = content.replace(/[{}\|\\\^~\[\]`"<>#%]/g, function(match) {
 		return '%'+match[0].charCodeAt(0).toString(16).toUpperCase();
 	});
 
-	var data = 'data:image/svg+xml;charset=utf8,' + content;
+	var data = 'data:image/svg+xml;charset=utf8,' + content.trim();
 	if (!query.noquotes) {
 		data = '"'+data+'"';
 	}

--- a/test/loader.spec.js
+++ b/test/loader.spec.js
@@ -69,7 +69,7 @@ describe('svg-url-loader', function() {
                 expect(err).to.be(null);
                 var encoded = (0,eval)(data.toString());
                 expect(encoded.indexOf('data:image/svg+xml;charset=utf8,%3Csvg')).to.be(0);
-                expect(encoded.lastIndexOf('svg%3E')).to.be(encoded.length - 'svg%3E'.length - 1);
+                expect(encoded.lastIndexOf('svg%3E')).to.be(encoded.length - 'svg%3E'.length);
                 return done();
             });
         });


### PR DESCRIPTION
New line characters causing issues in generated css. All white-spaces should  be replaced by a single space.