### PR TITLE
Fix calling without query throws TypeError

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var loaderUtils = require('loader-utils');
 module.exports = function(content) {
 	this.cacheable && this.cacheable();
 
-	var query = loaderUtils.getOptions(this);
+	var query = loaderUtils.getOptions(this) || {};
 
 	var limit = query.limit ? parseInt(query.limit, 10) : 0;
 


### PR DESCRIPTION
`require('loader-utils').parseOptions()` can return `null` when the query is empty. It makes the loader throw errors.
