### PR TITLE
fixes #141: Allows for a new option 'base64' to enable base64 encoding, while still taking advantage of the 4096 byte limit checking for IE 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,16 @@ Internet Explorer (including IE11) stops parsing style-elements in SVG data-URIs
 require('svg-url-loader?iesafe!./file.svg');
 ```
 
+### `encoding`
+
+This option controls which encoding to use when constructing a data-URI for an SVG. When set to a non-"none" value, quotes are never applied to the outputted data-URI. 
+
+Possible values are "base64" and "none". Defaults to "none".
+
+``` javascript
+require('svg-url-loader?encoding=base64!./file.svg');
+```
+
 ## Usage
 
 [Documentation: Loaders](https://webpack.js.org/concepts/loaders/)

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ module.exports = function(content) {
 	this.cacheable && this.cacheable();
 
 	var query = loaderUtils.getOptions(this) || {};
+	query.encoding = query.encoding || "none";
 
 	var limit = query.limit ? parseInt(query.limit, 10) : 0;
 
@@ -21,7 +22,7 @@ module.exports = function(content) {
 		}
 
 		var data;
-		if (query.base64) {
+		if (query.encoding === "base64") {
 			if (typeof newContent === "string") {
 				newContent = new Buffer(newContent);
 			}
@@ -38,7 +39,7 @@ module.exports = function(content) {
 		}
 
 		if (!(query.iesafe && hasStyleElement && data.length > 4096)) {
-			if (!query.base64 && !query.noquotes) {
+			if (query.encoding === "none" && !query.noquotes) {
 				data = '"'+data+'"';
 			}
 

--- a/index.js
+++ b/index.js
@@ -20,16 +20,25 @@ module.exports = function(content) {
 			newContent = newContent.replace(/^\s*<\?xml [^>]*>\s*/i, "");
 		}
 
-		newContent = newContent.replace(/"/g, "'");
-		newContent = newContent.replace(/\s+/g, " ");
-		newContent = newContent.replace(/[{}\|\\\^~\[\]`"<>#%]/g, function(match) {
-			return '%'+match[0].charCodeAt(0).toString(16).toUpperCase();
-		});
+		var data;
+		if (query.base64) {
+			if (typeof newContent === "string") {
+				newContent = new Buffer(newContent);
+			}
+			data = "data:image/svg+xml;base64," + newContent.toString("base64");
+		} else {
+			newContent = newContent.replace(/"/g, "'");
+			newContent = newContent.replace(/\s+/g, " ");
+			newContent = newContent.replace(/[{}\|\\\^~\[\]`"<>#%]/g, function(match) {
+				return '%'+match[0].charCodeAt(0).toString(16).toUpperCase();
+			});
 
-		var data = 'data:image/svg+xml,' + newContent.trim();
+			data = 'data:image/svg+xml,' + newContent.trim();
+
+		}
 
 		if (!(query.iesafe && hasStyleElement && data.length > 4096)) {
-			if (!query.noquotes) {
+			if (!query.base64 && !query.noquotes) {
 				data = '"'+data+'"';
 			}
 

--- a/test/loader.spec.js
+++ b/test/loader.spec.js
@@ -324,7 +324,7 @@ describe('svg-url-loader', function() {
             });
             config.module.rules[0].use[0].options.iesafe = true;
             config.module.rules[0].use[0].options.name = 'foo.svg';
-            config.module.rules[0].use[0].options.base64 = true;
+            config.module.rules[0].use[0].options.encoding = "base64";
 
             webpack(config, function(err) {
                 expect(err).to.be(null);
@@ -338,12 +338,12 @@ describe('svg-url-loader', function() {
         });
     });
 
-    describe("base64", function() {
+    describe("encoding is base64", function() {
         it('should convert SVG file to base64 encoded data-uri string', function(done) {
             var config = assign({}, globalConfig, {
                 entry: './test/input/icon.js'
             });
-            config.module.rules[0].use[0].options.base64 = true;
+            config.module.rules[0].use[0].options.encoding = "base64";
 
             webpack(config, function(err) {
                 expect(err).to.be(null);

--- a/test/loader.spec.js
+++ b/test/loader.spec.js
@@ -317,5 +317,45 @@ describe('svg-url-loader', function() {
                 });
             });
         });
+
+        it('should fall back on file above limit with style-element even when base64 encoding', function(done) {
+            var config = assign({}, globalConfig, {
+                entry: './test/input/4099B-encoded-styled.js'
+            });
+            config.module.rules[0].use[0].options.iesafe = true;
+            config.module.rules[0].use[0].options.name = 'foo.svg';
+            config.module.rules[0].use[0].options.base64 = true;
+
+            webpack(config, function(err) {
+                expect(err).to.be(null);
+                fs.readFile(getBundleFile(), function(err, data) {
+                    expect(err).to.be(null);
+                    var encoded = (0,eval)(data.toString());
+                    expect(encoded).to.be('foo.svg');
+                    return done();
+                });
+            });
+        });
+    });
+
+    describe("base64", function() {
+        it('should convert SVG file to base64 encoded data-uri string', function(done) {
+            var config = assign({}, globalConfig, {
+                entry: './test/input/icon.js'
+            });
+            config.module.rules[0].use[0].options.base64 = true;
+
+            webpack(config, function(err) {
+                expect(err).to.be(null);
+                fs.readFile(getBundleFile(), function(err, data) {
+                    expect(err).to.be(null);
+                    var encoded = (0,eval)(data.toString());
+                    expect(encoded.indexOf('"')).to.be(-1);
+                    expect(encoded.lastIndexOf('"')).to.be(-1);
+                    expect(encoded.indexOf('data:image/svg+xml;base64')).to.be(0);
+                    return done();
+                });
+            });
+        });
     });
 });


### PR DESCRIPTION
This PR allows for a new option to be passed into the loader, `base64`. While using `base64` isn't as efficient as just embedding the escaped XML, there are a few use cases for sticking with base64, while still taking advantage of the 4096 byte limit detection:

- No need to have separate loader config for JS vs CSS
- Accessing an element via ID will work on base64 encoded svgs. e.g with escaped xml.

`url('~css/fonts/AtlassianMarketplaceIcons.svg?gn9zjl#icomoon')` unfortunately outputs:
`url("%3C!DOCTYPE svg PUBLIC '-//W3C//DTD SVG 1.1//EN' 'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd' %3E %3Csvg xmlns='http://www.w3.org/2000/svg'%3E %3Cmetadata%3E ..."#icomoon)` which is invalid.