### PR TITLE
Fix 'iesafe' to detect style-elements with linebreaks

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports = function(content) {
 	if (limit <= 0 || content.length < limit) {
 		var newContent = content.toString('utf8');
 
-		var hasStyleElement = /<style.*?>.*?<\/style>/i.test(newContent)
+		var hasStyleElement = /<style[\s\S]*?>[\s\S]*?<\/style>/i.test(newContent)
 
 		if (query.stripdeclarations) {
 			newContent = newContent.replace(/^\s*<\?xml [^>]*>\s*/i, "");


### PR DESCRIPTION
Should fix #127.

Since `.` doesn't match newlines, only one-line style-tags were detected. Pretty-printed SVGs, such as those produced by many tools, would thus not register as having a style tag unless run through an optimiser first.

Should there be test-cases for this? The current test-SVGs were generated for the purpose of having a specific length and are without whitespace.

Should the test for style-tags be simplified? Just testing for the presence of `<style` would very rarely produce false positives, and the worst case scenario would be a bailout, whereas a missed style-tag will cause a silent error that is only discovered in thorough cross-browser testing.