### PR TITLE
Added option 'emitWarnings' to identify unprocessed files

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,14 @@ Possible values are "base64" and "none". Defaults to "none".
 require('svg-url-loader?encoding=base64!./file.svg');
 ```
 
+### `emitWarnings`
+
+This option helps to identify unprocessed files. This can happen, if the `limit` and/or `iesafe` options are active. 
+
+``` javascript
+require('svg-url-loader?emitWarnings!./file.svg');
+```
+
 ## Usage
 
 [Documentation: Loaders](https://webpack.js.org/concepts/loaders/)

--- a/index.js
+++ b/index.js
@@ -38,13 +38,19 @@ module.exports = function(content) {
 
 		}
 
-		if (!(query.iesafe && hasStyleElement && data.length > 4096)) {
+		if (query.iesafe && hasStyleElement && data.length > 4096) {
+			if (query.emitWarnings) {
+				this.emitWarning(`Content was not processed, as 'iesafe' option is active.`);
+			}
+		} else {
 			if (query.encoding === "none" && !query.noquotes) {
 				data = '"'+data+'"';
 			}
 
 			return 'module.exports = ' + JSON.stringify(data);
 		}
+	} else if (query.emitWarnings) {
+		this.emitWarning(`Content size (${content.length} byte) is over the limit of ${limit} byte.`)
 	}
 
 	var fileLoader = require('file-loader');


### PR DESCRIPTION
Hello there,

as we have two options, which will prevent processing of files, we should have an option to identify these unprocessed files.

You might consider to default this to true or warn without the option, as it should be useful in most cases.
I could do this, if you give me some feedback. :+1: 

Regards!