### PR TITLE
fix: handle boolean query parameters and add stripSpaces option

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,40 @@ module.exports = {
 };
 ```
 
+### `stripSpaces`
+
+This option is `true` by default.
+
+If set to `false`, the loader will not aggressively minify whitespaces (except newlines and multiple spaces). This is useful when you need to preserve significant whitespace inside SVG `<text>` elements.
+
+You can specify the `stripSpaces` option in the query:
+
+```javascript
+require("svg-url-loader?stripSpaces=false!./file.svg");
+```
+
+Or set it globally in your webpack config:
+
+```javascript
+module.exports = {
+  //...
+  module: {
+    rules: [
+      {
+        test: /\.svg/,
+        use: {
+          loader: "svg-url-loader",
+          options: {
+            stripSpaces: false,
+          },
+        },
+      },
+    ],
+  },
+  //...
+};
+```
+
 ### `encoding`
 
 This option controls which encoding to use when constructing a data-URI for an SVG. When set to a non-"none" value, loader does not apply quotes to the resulting data-URI.

--- a/src/loader.js
+++ b/src/loader.js
@@ -4,12 +4,20 @@ const REGEX_MULTIPLE_SPACES = /\s+/g
 const REGEX_DOUBLE_QUOTE = /"/g
 const REGEX_UNSAFE_CHARS = /[{}\|\\\^~\[\]`"<>#%]/g
 
+function parseBoolean(value, defaultValue) {
+  if (typeof value === 'boolean') return value
+  if (value === 'true') return true
+  if (value === 'false') return false
+  return defaultValue
+}
+
 module.exports = function (content) {
   this.cacheable && this.cacheable()
 
   let query = {
     encoding: 'none',
     stripdeclarations: true,
+    stripSpaces: true,
     ...this.getOptions()
   }
 
@@ -20,12 +28,16 @@ module.exports = function (content) {
     }
   }
 
+  query.stripdeclarations = parseBoolean(query.stripdeclarations, true)
+  query.stripSpaces = parseBoolean(query.stripSpaces, true)
+  query.iesafe = parseBoolean(query.iesafe, false)
+
   let limit = query.limit ? parseInt(query.limit, 10) : 0
 
   if (limit <= 0 || content.length < limit) {
     const originalSvgSource = content.toString('utf8')
 
-    const transformedSvgSource = applyGeneralTransforms(originalSvgSource, query.stripdeclarations)
+    const transformedSvgSource = applyGeneralTransforms(originalSvgSource, query.stripdeclarations, query.stripSpaces)
 
     let data
     if (query.encoding === 'base64') {
@@ -57,10 +69,12 @@ function uriEncode(svgSource) {
   return svgSource.trim()
 }
 
-function applyGeneralTransforms(svgSource, stripXmlDeclaration) {
+function applyGeneralTransforms(svgSource, stripXmlDeclaration, stripSpaces) {
   if (stripXmlDeclaration) {
     svgSource = svgSource.replace(REGEX_XML_DECLARATION, '')
   }
-  svgSource = svgSource.replace(REGEX_MULTIPLE_SPACES, ' ')
+  if (stripSpaces) {
+    svgSource = svgSource.replace(REGEX_MULTIPLE_SPACES, ' ')
+  }
   return svgSource
 }

--- a/test/input/icon-with-declaration-resource-query.js
+++ b/test/input/icon-with-declaration-resource-query.js
@@ -1,0 +1,2 @@
+var icon = require('./images/icon-with-declaration.svg?stripdeclarations=false')
+module.exports = icon

--- a/test/loader.spec.js
+++ b/test/loader.spec.js
@@ -73,7 +73,7 @@ describe('svg-url-loader', function () {
     it('if turned off in resourceQuery - should do nothing to an SVG that has an XML declaration', async () => {
       const config = {
         ...getBaseWebpackConfig(),
-        entry: './test/input/icon-with-declaration.js?stripdeclarations=false'
+        entry: './test/input/icon-with-declaration-resource-query.js'
       }
 
       const assetName = await runWebpack(config)
@@ -117,11 +117,11 @@ describe('svg-url-loader', function () {
 
       const assetName = await runWebpack(config)
       const encoded = await evaluateGeneratedBundle(assetName)
-      // This is a simplified check to ensure it doesn't strip ALL spaces, 
+      // This is a simplified check to ensure it doesn't strip ALL spaces,
       // it will still encode spaces as %20 or similar.
-      // If it stripped spaces, it would be a single space, 
-      // and it would likely not contain %0a (newline encoded)
-      expect(encoded).toContain('%0a')
+      // If it stripped spaces, it would be a single space,
+      // and it would likely not contain \n (newline)
+      expect(encoded).toContain('\n')
     })
   })
 

--- a/test/loader.spec.js
+++ b/test/loader.spec.js
@@ -70,6 +70,17 @@ describe('svg-url-loader', function () {
       expect(encoded).toContain("%3c?xml version='1.0' encoding='UTF-8'?%3e")
     })
 
+    it('if turned off in resourceQuery - should do nothing to an SVG that has an XML declaration', async () => {
+      const config = {
+        ...getBaseWebpackConfig(),
+        entry: './test/input/icon-with-declaration.js?stripdeclarations=false'
+      }
+
+      const assetName = await runWebpack(config)
+      const encoded = await evaluateGeneratedBundle(assetName)
+      expect(encoded).toContain("%3c?xml version='1.0' encoding='UTF-8'?%3e")
+    })
+
     it("if turned on - should do nothing to an SVG that doesn't have an XML declaration", async () => {
       const config = {
         ...getBaseWebpackConfig(),
@@ -93,6 +104,24 @@ describe('svg-url-loader', function () {
       const encoded = await evaluateGeneratedBundle(assetName)
       expect(encoded).not.toContain('%3c?xml version="1.0" encoding="UTF-8"?%3e')
       expect(encoded.startsWith('data:image/svg+xml,%3csvg')).toBe(true)
+    })
+  })
+
+  describe('"stripSpaces" option', function () {
+    it('if turned off - should preserve extra spaces', async () => {
+      const config = {
+        ...getBaseWebpackConfig(),
+        entry: './test/input/icon.js'
+      }
+      config.module.rules[0].use[0].options.stripSpaces = false
+
+      const assetName = await runWebpack(config)
+      const encoded = await evaluateGeneratedBundle(assetName)
+      // This is a simplified check to ensure it doesn't strip ALL spaces, 
+      // it will still encode spaces as %20 or similar.
+      // If it stripped spaces, it would be a single space, 
+      // and it would likely not contain %0a (newline encoded)
+      expect(encoded).toContain('%0a')
     })
   })
 


### PR DESCRIPTION
1. Summary of changes
   - Fixed a bug where boolean query parameters (`stripdeclarations`, `iesafe`) were being incorrectly parsed as strings, causing them to always be treated as truthy.
   - Added a `stripSpaces` option to the loader to optionally disable whitespace minification, allowing users to preserve important spacing in SVG text elements.
   - Implemented a `parseBoolean` helper to ensure query options are correctly normalized into booleans, regardless of whether they come from the webpack config or the resource query string.
   - Updated `applyGeneralTransforms` to incorporate the `stripSpaces` option.
   - Added test cases to verify the correct behavior of `stripdeclarations=false` in the resource query and the `stripSpaces` option.

2. Rationale behind the implementation
   - The boolean query parameter parsing bug was critical, as it rendered options like `stripdeclarations=false` or `iesafe=false` ineffective.
   - The addition of `stripSpaces` addresses a limitation where the loader's aggressive minification could negatively impact SVGs containing text elements, providing users with more control over the transformation process.

3. Technical impact analysis
   - The changes are backward-compatible, as the default values for `stripdeclarations` and `stripSpaces` remain `true`.
   - The new `parseBoolean` function correctly handles both boolean and string inputs, ensuring robustness across different ways of passing loader options.
   - The changes improve the loader's reliability and flexibility for users with diverse SVG requirements.